### PR TITLE
Add global context and interface with ServerAPI

### DIFF
--- a/src/animation-manager/AnimationBrowserPage.tsx
+++ b/src/animation-manager/AnimationBrowserPage.tsx
@@ -1,10 +1,15 @@
-import { useEffect, FC } from "react";
+import { useEffect, FC } from 'react';
+import { useAnimationContext } from '../state';
 
 export const AnimationBrowserPage: FC = () => {
   
+  const { loadSets, animationSets } = useAnimationContext();
+
   // Runs upon opening the page
   useEffect(() => {
-    //
+    
+    loadSets();
+    
   }, []);
 
   return (
@@ -12,7 +17,13 @@ export const AnimationBrowserPage: FC = () => {
       <h2
         style={{ fontWeight: "bold", fontSize: "1.5em", marginBottom: "0px" }}
       >
-        TODO
+        
+        {animationSets.map((set) => (
+          <div key={set.id}>
+            {set.boot}
+          </div>
+        ))}
+
       </h2>
     </div>
   );

--- a/src/animation-manager/AnimationBrowserPage.tsx
+++ b/src/animation-manager/AnimationBrowserPage.tsx
@@ -1,4 +1,7 @@
 import { useEffect, FC } from 'react';
+import { Focusable, PanelSectionRow, Dropdown } from 'decky-frontend-lib';
+import RepoResultCard from './RepoResultCard';
+
 import { useAnimationContext } from '../state';
 
 export const AnimationBrowserPage: FC = () => {
@@ -13,23 +16,20 @@ export const AnimationBrowserPage: FC = () => {
   }, []);
 
   return (
-    <div>
-      <h2
-        style={{ fontWeight: "bold", fontSize: "1.5em", marginBottom: "0px" }}
-      >
+    <>
+      <Focusable>
+        <PanelSectionRow>
+            {searchTotal} results found
+        </PanelSectionRow>
+      </Focusable>
+      
+      <Focusable style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', columnGap: '15px' }}>
+
+        {repoResults.map((result) => <RepoResultCard key={result.id} result={result} />)}
+
+      </Focusable>
         
-        TOTAL: {searchTotal}
-
-      </h2>
-
-      {repoResults.map((result) => (
-          <div key={result.id}>
-            <img src={result.thumbnail} width={300} />
-            {result.title}
-            <hr />
-          </div>
-        ))}
-    </div>
+    </>
   );
 };
   

--- a/src/animation-manager/AnimationBrowserPage.tsx
+++ b/src/animation-manager/AnimationBrowserPage.tsx
@@ -3,12 +3,12 @@ import { useAnimationContext } from '../state';
 
 export const AnimationBrowserPage: FC = () => {
   
-  const { loadSets, animationSets } = useAnimationContext();
+  const { searchRepo, repoResults, searchTotal } = useAnimationContext();
 
   // Runs upon opening the page
   useEffect(() => {
     
-    loadSets();
+    searchRepo();
     
   }, []);
 
@@ -18,13 +18,17 @@ export const AnimationBrowserPage: FC = () => {
         style={{ fontWeight: "bold", fontSize: "1.5em", marginBottom: "0px" }}
       >
         
-        {animationSets.map((set) => (
-          <div key={set.id}>
-            {set.boot}
-          </div>
-        ))}
+        TOTAL: {searchTotal}
 
       </h2>
+
+      {repoResults.map((result) => (
+          <div key={result.id}>
+            <img src={result.thumbnail} width={300} />
+            {result.title}
+            <hr />
+          </div>
+        ))}
     </div>
   );
 };

--- a/src/animation-manager/RepoResultCard.tsx
+++ b/src/animation-manager/RepoResultCard.tsx
@@ -1,0 +1,65 @@
+import { FC } from 'react';
+import { RepoResult } from '../types/animation';
+import { Focusable } from 'decky-frontend-lib';
+
+const RepoResultCard: FC<{ result: RepoResult }> = ({ result }) => {
+
+  return (
+    
+    <Focusable
+    className="Panel"
+    style={{
+      margin: 0,
+      marginBottom: '15px'
+    }}>
+      
+      <div
+      className="gamepadhomewhatsnew_OuterWrapper_3DpEz"
+      style={{
+        height: '317px'
+      }}>
+        
+        <div className="gamepadhomewhatsnew_EventType_1f0dZ gamepadhomewhatsnew_EventType28_39b83">
+          Animation
+        </div>
+
+        <div className="gamepadhomewhatsnew_EventPreviewContainer_1ltOY Panel Focusable">
+          
+          <div className="gamepadhomewhatsnew_EventImageWrapper_XLJ9p">
+            <img
+              src={result.thumbnail}
+              style={{ maxWidth: '100%', height: 'auto', width: 'auto' }}
+              className="gamepadhomewhatsnew_EventImage_116GS"/>
+            <div className="gamepadhomewhatsnew_Darkener_1n_1X"></div>
+            <div className="gamepadhomewhatsnew_EventSummary_UE_Ms"></div>
+          </div>
+
+          <div className="gamepadhomewhatsnew_EventInfo_6TGe7 partnereventdisplay_InLibraryView_3X6U9">
+            <div className="partnereventdisplay_EventDetailTimeInfo_3Z41s">
+              <div className="Focusable">
+                <div className="localdateandtime_RightSideTitles_3sPON">Likes</div>
+                <div className="localdateandtime_ShortDateAndTime_4K3Bl">{result.likes}</div>
+              </div>
+            </div>
+            <div className="gamepadhomewhatsnew_Title_1QLHG">{result.title}</div>
+            <div className="gamepadhomewhatsnew_GameIconAndName_1jXSh">
+              <div
+                className="libraryassetimage_Container_1R9r2 libraryassetimage_GreyBackground_2E7G8 gamepadhomewhatsnew_GameIcon_2RrB8">
+                <img src={result.user.steam_avatar}
+                  className="libraryassetimage_Image_24_Au libraryassetimage_Visibility_3d_bT libraryassetimage_Visible_yDr03"
+                  alt={result.user.steam_name} />
+              </div>
+              <div className="gamepadhomewhatsnew_GameName_3H9W-">{result.user.steam_name}</div>
+            </div>
+          </div>
+
+        </div>
+
+      </div>
+
+    </Focusable>
+  );
+
+  }
+
+  export default RepoResultCard;

--- a/src/animation-manager/RepoResultCard.tsx
+++ b/src/animation-manager/RepoResultCard.tsx
@@ -7,6 +7,7 @@ const RepoResultCard: FC<{ result: RepoResult }> = ({ result }) => {
   return (
     
     <Focusable
+    focusClassName='gpfocuswithin'
     className="Panel"
     style={{
       margin: 0,

--- a/src/animation-manager/RepoResultCard.tsx
+++ b/src/animation-manager/RepoResultCard.tsx
@@ -4,16 +4,13 @@ import { Focusable } from 'decky-frontend-lib';
 
 const RepoResultCard: FC<{ result: RepoResult }> = ({ result }) => {
 
-  return (
-    
-    <Focusable
-    focusClassName='gpfocuswithin'
-    className="Panel"
-    style={{
+  return (      
+
+    <div className='Panel' style={{
       margin: 0,
       marginBottom: '15px'
     }}>
-      
+
       <div
       className="gamepadhomewhatsnew_OuterWrapper_3DpEz"
       style={{
@@ -24,7 +21,14 @@ const RepoResultCard: FC<{ result: RepoResult }> = ({ result }) => {
           Animation
         </div>
 
-        <div className="gamepadhomewhatsnew_EventPreviewContainer_1ltOY Panel Focusable">
+        <Focusable
+        focusWithinClassName='gpfocuswithin'
+        className="gamepadhomewhatsnew_EventPreviewContainer_1ltOY Panel"
+        onActivate={() => { console.log('clicked') }}
+        style={{
+          margin: 0,
+          marginBottom: '15px'
+        }}>
           
           <div className="gamepadhomewhatsnew_EventImageWrapper_XLJ9p">
             <img
@@ -32,15 +36,15 @@ const RepoResultCard: FC<{ result: RepoResult }> = ({ result }) => {
               style={{ maxWidth: '100%', height: 'auto', width: 'auto' }}
               className="gamepadhomewhatsnew_EventImage_116GS"/>
             <div className="gamepadhomewhatsnew_Darkener_1n_1X"></div>
-            <div className="gamepadhomewhatsnew_EventSummary_UE_Ms"></div>
+            <div className="gamepadhomewhatsnew_EventSummary_UE_Ms">This is a test</div>
           </div>
 
           <div className="gamepadhomewhatsnew_EventInfo_6TGe7 partnereventdisplay_InLibraryView_3X6U9">
             <div className="partnereventdisplay_EventDetailTimeInfo_3Z41s">
-              <div className="Focusable">
+              <Focusable>
                 <div className="localdateandtime_RightSideTitles_3sPON">Likes</div>
                 <div className="localdateandtime_ShortDateAndTime_4K3Bl">{result.likes}</div>
-              </div>
+              </Focusable>
             </div>
             <div className="gamepadhomewhatsnew_Title_1QLHG">{result.title}</div>
             <div className="gamepadhomewhatsnew_GameIconAndName_1jXSh">
@@ -54,11 +58,11 @@ const RepoResultCard: FC<{ result: RepoResult }> = ({ result }) => {
             </div>
           </div>
 
-        </div>
+        </Focusable>
 
       </div>
 
-    </Focusable>
+    </div>
   );
 
   }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,8 +11,12 @@ import {
     Tabs,
     Router
 } from "decky-frontend-lib";
+
 import { useEffect, useState, FC } from "react";
 import { FaRandom } from "react-icons/fa";
+
+import { AnimationChangerContext, AnimationChangerContextInterface } from './state';
+
 
 import {
     AnimationBrowserPage,
@@ -190,13 +194,26 @@ const AnimationManagerRouter: FC = () => {
   
 export default definePlugin((serverApi: ServerAPI) => {
 
+    const test: AnimationChangerContextInterface = {
+        name: "Test",
+        author: "Testing",
+        url: "123"
+    };
+
     serverApi.routerHook.addRoute("/animation-manager", () => (
-        <AnimationManagerRouter />
+        <AnimationChangerContext.Provider value={test}>
+            <AnimationManagerRouter />
+        </AnimationChangerContext.Provider>
     ));
 
     return {
         title: <div className={staticClasses.Title}>Animation Changer</div>,
-        content: <Content serverAPI={serverApi}/>,
+        content: (
+            <AnimationChangerContext.Provider value={test}>
+                <Content serverAPI={serverApi}/>
+            </AnimationChangerContext.Provider>
+        ),
         icon: <FaRandom/>
     };
+
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,7 +15,7 @@ import {
 import { useEffect, useState, FC } from "react";
 import { FaRandom } from "react-icons/fa";
 
-import { AnimationChangerContext, AnimationChangerContextInterface } from './state';
+import { AnimationProvider } from './state';
 
 
 import {
@@ -194,24 +194,18 @@ const AnimationManagerRouter: FC = () => {
   
 export default definePlugin((serverApi: ServerAPI) => {
 
-    const test: AnimationChangerContextInterface = {
-        name: "Test",
-        author: "Testing",
-        url: "123"
-    };
-
     serverApi.routerHook.addRoute("/animation-manager", () => (
-        <AnimationChangerContext.Provider value={test}>
+        <AnimationProvider serverAPI={serverApi}>
             <AnimationManagerRouter />
-        </AnimationChangerContext.Provider>
+        </AnimationProvider>
     ));
 
     return {
         title: <div className={staticClasses.Title}>Animation Changer</div>,
         content: (
-            <AnimationChangerContext.Provider value={test}>
+            <AnimationProvider serverAPI={serverApi}>
                 <Content serverAPI={serverApi}/>
-            </AnimationChangerContext.Provider>
+            </AnimationProvider>
         ),
         icon: <FaRandom/>
     };

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -1,9 +1,0 @@
-import { createContext } from 'react';
-
-export interface AnimationChangerContextInterface {
-  name: string;
-  author: string;
-  url: string;
-}
-
-export const AnimationChangerContext = createContext<AnimationChangerContextInterface | null>(null);

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+
+export interface AnimationChangerContextInterface {
+  name: string;
+  author: string;
+  url: string;
+}
+
+export const AnimationChangerContext = createContext<AnimationChangerContextInterface | null>(null);

--- a/src/state/index.tsx
+++ b/src/state/index.tsx
@@ -5,19 +5,25 @@ import {
   useContext
 } from 'react';
 
+import { ToastData } from 'decky-frontend-lib';
+
 import {
   AnimationContextType,
   AnimationProviderType,
   Animation,
-  AnimationSet
+  AnimationSet,
+  RepoResult,
 } from '../types/animation';
 
 const AnimationContext = createContext<AnimationContextType | null>(null);
 
 export const AnimationProvider: FC<AnimationProviderType> = ({ serverAPI, children }) => {
 
-  const [ animations, setAnimations ] = useState<Animation[]>([]);
+  const [ page, setPage ] = useState(0);
+  const [ searchTotal, setSearchTotal ] = useState(0);
+  const [ repoResults, setRepoResults ] = useState<RepoResult[]>([]);
 
+  const [ animations, setAnimations ] = useState<Animation[]>([]);
   const [ animationSets, setAnimationSets ] = useState<AnimationSet[]>([]);
 
   /**
@@ -30,11 +36,39 @@ export const AnimationProvider: FC<AnimationProviderType> = ({ serverAPI, childr
     }
   };
 
+  const searchRepo = async (sort?: string, query?: string, page?: number) => {
+
+    // TODO: make sort an enum
+    // TODO: pull query through
+    // TODO: setup pagination
+
+    const response = await serverAPI.fetchNoCors<{ body: string }>('https://steamdeckrepo.com/?sort=likes-desc', {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+        'X-Inertia': 'true',
+        'X-Inertia-Version': 'f182274c1534a5980b2777586ce52800'
+      }
+    });
+
+    if(response.success) {
+      const data = JSON.parse(response.result.body);
+      setRepoResults(data.props.posts.data);
+      setSearchTotal(data.props.meta.total);
+    }
+
+  }
+
   return (
     <AnimationContext.Provider value={{
       animations,
       animationSets,
-      loadSets
+      loadSets,
+      page,
+      searchTotal,
+      repoResults,
+      searchRepo
     }}>
       {children}
     </AnimationContext.Provider>

--- a/src/state/index.tsx
+++ b/src/state/index.tsx
@@ -55,7 +55,7 @@ export const AnimationProvider: FC<AnimationProviderType> = ({ serverAPI, childr
     if(response.success) {
       const data = JSON.parse(response.result.body);
       setRepoResults(data.props.posts.data);
-      setSearchTotal(data.props.meta.total);
+      setSearchTotal(data.props.posts.meta.total);
     }
 
   }

--- a/src/state/index.tsx
+++ b/src/state/index.tsx
@@ -1,7 +1,8 @@
 import {
   createContext,
   FC,
-  useState
+  useState,
+  useContext
 } from 'react';
 
 import {
@@ -40,3 +41,5 @@ export const AnimationProvider: FC<AnimationProviderType> = ({ serverAPI, childr
   );
 
 }
+
+export const useAnimationContext = () => useContext(AnimationContext) as AnimationContextType;

--- a/src/state/index.tsx
+++ b/src/state/index.tsx
@@ -1,0 +1,42 @@
+import {
+  createContext,
+  FC,
+  useState
+} from 'react';
+
+import {
+  AnimationContextType,
+  AnimationProviderType,
+  Animation,
+  AnimationSet
+} from '../types/animation';
+
+const AnimationContext = createContext<AnimationContextType | null>(null);
+
+export const AnimationProvider: FC<AnimationProviderType> = ({ serverAPI, children }) => {
+
+  const [ animations, setAnimations ] = useState<Animation[]>([]);
+
+  const [ animationSets, setAnimationSets ] = useState<AnimationSet[]>([]);
+
+  /**
+   * Load the sets from the server API.
+   */
+  const loadSets = async () => {
+    const response = await serverAPI.callPluginMethod('getSets', {});
+    if(response.success) {
+      setAnimationSets(response.result as AnimationSet[]);
+    }
+  };
+
+  return (
+    <AnimationContext.Provider value={{
+      animations,
+      animationSets,
+      loadSets
+    }}>
+      {children}
+    </AnimationContext.Provider>
+  );
+
+}

--- a/src/types/animation.d.ts
+++ b/src/types/animation.d.ts
@@ -1,6 +1,28 @@
 import { ReactNode } from 'react';
 import { ServerAPI } from 'decky-frontend-lib';
 
+export interface RepoResult {
+  id: string;
+  slug: string;
+  title: string;
+  content: string;
+  user: RepoUser;
+  thumbnail: string;
+  video: string;
+  video_preview: string;
+  created_at: string;
+  updated_at: string;
+  url: string;
+  likes: number;
+  downloads: number;
+}
+
+export interface RepoUser {
+  id: number;
+  steam_name: string;
+  steam_avatar: string;
+}
+
 export interface Animation {
   id: string;
   title: string;
@@ -18,7 +40,11 @@ export interface AnimationSet {
 export type AnimationContextType = {
   animations: Animation[];
   animationSets: AnimationSet[];
+  repoResults: RepoResult[];
+  searchTotal: number;
+  page: number;
   loadSets: () => void;
+  searchRepo: (sort?: string, query?: string, page?: number) => void;
 }
 
 export interface AnimationProviderType extends ReactNode {

--- a/src/types/animation.d.ts
+++ b/src/types/animation.d.ts
@@ -1,0 +1,26 @@
+import { ReactNode } from 'react';
+import { ServerAPI } from 'decky-frontend-lib';
+
+export interface Animation {
+  id: string;
+  title: string;
+  author: string;
+}
+
+export interface AnimationSet {
+  id: string;
+  boot: string | null;
+  suspend: string | null;
+  throbber: string | null;
+  enabled: boolean;
+}
+
+export type AnimationContextType = {
+  animations: Animation[];
+  animationSets: AnimationSet[];
+  loadSets: () => void;
+}
+
+export interface AnimationProviderType extends ReactNode {
+  serverAPI: ServerAPI
+}


### PR DESCRIPTION
Hey @TheLogicMaster,

I've started hooking into the work you did last night on the backend. This adds a global React context to the plugin so we can maintain the state between the sidebar views and theme manager.

There's a `useAnimationContext` hook that includes the functions and interfaces we'll need. Currently this is defined as:

```ts
export type AnimationContextType = {
  animations: Animation[];
  animationSets: AnimationSet[];
  loadSets: () => void;
}
```

If you open up the Theme Manager you should see that it will load the sets from the backend. I messaged you on Discord but we'll need more info for these sets and animations to tie it in with the data from SteamDeckRepo.

I'll also need methods to load the data from SteamDeckRepo. For now I'm going to use the cache method you added so I can style out that screen. We'll also need a method for me to send a UUID to the backend so it can then be downloaded.

Let me know if you have any questions or issues.

- Steve